### PR TITLE
make the website name not have a hyphen when authenticating

### DIFF
--- a/src/resources/authentication.js
+++ b/src/resources/authentication.js
@@ -32,7 +32,7 @@ class Authentication {
             window.addEventListener("message", handleMessageReciever);
 
             login = window.open(
-                `https://auth.itinerary.eu.org/auth/?redirect=${base64}&name=Snail-IDE`,
+                `https://auth.itinerary.eu.org/auth/?redirect=${base64}&name=Snail%20IDE`,
                 "Scratch Authentication",
                 `scrollbars=yes,resizable=yes,status=no,location=yes,toolbar=no,menubar=no,width=1024,height=512,left=200,top=200`
             );


### PR DESCRIPTION
Make it so when signing in, there Scratch Auth shows "Sign in to Snail IDE with Scratch" instead of "Sign in to Snail-IDE with Scratch"

I'm not sure if the hyphen is intentional, so sorry for making this if it is.